### PR TITLE
Fix friend notification icon

### DIFF
--- a/app/src/main/java/moe/shizuku/fcmformojo/notification/NotificationBuilderImplP.java
+++ b/app/src/main/java/moe/shizuku/fcmformojo/notification/NotificationBuilderImplP.java
@@ -46,7 +46,7 @@ public class NotificationBuilderImplP extends NotificationBuilderImplO {
             User sender = message.getSenderUser();
 
             IconCompat icon = null;
-            Bitmap bitmap = UserIcon.getIcon(context, sender.getUid(), Chat.ChatType.FRIEND);
+            Bitmap bitmap = UserIcon.getIcon(context,chat.getUid(), Chat.ChatType.FRIEND);
             if (bitmap != null) {
                 icon = IconCompat.createWithBitmap(bitmap);
             }


### PR DESCRIPTION
在接收到消息后新建的sender uid 为0，故会导致所有好友私聊头像均变成默认，直接调用chat的uid即可
另：android p中同样也无法显示群组内发言者的头像，我并没有找到能够获取sender uid的方法，所以暂时没什么办法